### PR TITLE
fix lines on simple view

### DIFF
--- a/AskSinAnalyzerESP32/Display.h
+++ b/AskSinAnalyzerESP32/Display.h
@@ -24,8 +24,10 @@ void drawStatusCircle(uint16_t color) {
 void drawRowLines() {
   if (showDisplayLines == true) {
     tft.drawLine(0, 14, tft.width(), 14, ILI9341_WHITE);
-    for (uint8_t c = 0; c < DISPLAY_LOG_LINES; c++)
-      tft.drawLine(0, DISPLAY_LOG_OFFSET_TOP + (2 * DISPLAY_LOG_LINE_HEIGHT) + (DISPLAY_LOG_LINE_HEIGHT * LOG_BLOCK_SIZE * c) + 2, tft.width(), DISPLAY_LOG_OFFSET_TOP + (2 * DISPLAY_LOG_LINE_HEIGHT) + (DISPLAY_LOG_LINE_HEIGHT * LOG_BLOCK_SIZE * c) + 2, ILI9341_WHITE);
+    for (uint8_t c = 0; c < DISPLAY_LOG_LINES; c++) {
+      int y = DISPLAY_LOG_OFFSET_TOP + (DISPLAY_LOG_LINE_HEIGHT * LOG_BLOCK_SIZE * (c+1)) - DISPLAY_LOG_LINE_HEIGHT + 2;
+      tft.drawLine(0, y, tft.width(), y, ILI9341_WHITE);
+    }
   }
 }
 
@@ -98,8 +100,10 @@ void refreshDisplayLog() {
       u8g.setForegroundColor(ILI9341_OLIVE);
       u8g.print(LogTable[c].flags);
     }
-    if (showDisplayLines == true)
-      tft.drawLine(0, DISPLAY_LOG_OFFSET_TOP + (2 * DISPLAY_LOG_LINE_HEIGHT) + (DISPLAY_LOG_LINE_HEIGHT * LOG_BLOCK_SIZE * c) + 2, tft.width(), DISPLAY_LOG_OFFSET_TOP + (2 * DISPLAY_LOG_LINE_HEIGHT) + (DISPLAY_LOG_LINE_HEIGHT * LOG_BLOCK_SIZE * c) + 2, ILI9341_WHITE);
+    if (showDisplayLines == true) {
+      int y = DISPLAY_LOG_OFFSET_TOP + (DISPLAY_LOG_LINE_HEIGHT * LOG_BLOCK_SIZE * (c+1)) - DISPLAY_LOG_LINE_HEIGHT + 2;
+      tft.drawLine(0, y, tft.width(), y, ILI9341_WHITE);
+    }
   }
 
   u8g.setCursor(78, 10);


### PR DESCRIPTION
On the simple view the lines are not positioned correctly and overwritten by the text:
![display_broken_lines](https://user-images.githubusercontent.com/4477518/61814505-85f7d200-ae48-11e9-8d5a-12158d01bb57.jpg)

Fixed:
![display_lines_repaired](https://user-images.githubusercontent.com/4477518/61814504-85f7d200-ae48-11e9-9728-4ff9ecfcae7e.jpg)

The detailed view is still working.

Description:
The formula is calculating the y position of the next line (works for both simple and detailed view) and then subtracts one line height.

Moving the calculation of the y position to a dedicated variable just makes the code easier to read. The compiler would have calculated it only once anyway.