### PR TITLE
Windows ide fix

### DIFF
--- a/AskSinAnalyzerESP32/AskSinAnalyzerESP32.ino
+++ b/AskSinAnalyzerESP32/AskSinAnalyzerESP32.ino
@@ -7,8 +7,6 @@
 //- -----------------------------------------------------------------------------------------------------------------------
 
 #define USE_DISPLAY
-const String CCU_SV_DEVLIST = "AskSinAnalyzerDevList";  //name of the used system variable on the CCU containing the device list
-const String CCU_SV_ALARM   = "AskSinAnalyzerAlarm";  //name of the used system variable on the CCU for alarms
 // #define NDEBUG //No DEBUG -> no output
 #define VDEBUG //Verbose DEBUG -> more output
 
@@ -40,6 +38,9 @@ const String CCU_SV_ALARM   = "AskSinAnalyzerAlarm";  //name of the used system 
 #define HAS_DISPLAY 0
 #endif
 #include "RingBuffer.h"
+
+const String CCU_SV_DEVLIST = "AskSinAnalyzerDevList";  //name of the used system variable on the CCU containing the device list
+const String CCU_SV_ALARM   = "AskSinAnalyzerAlarm";  //name of the used system variable on the CCU for alarms
 
 #define VERSION_UPPER "3"
 #define VERSION_LOWER "4"

--- a/AskSinAnalyzerESP32/platformio.ini
+++ b/AskSinAnalyzerESP32/platformio.ini
@@ -14,10 +14,14 @@ monitor_speed = 57600
 
 lib_deps =
   ESP Async WebServer
+  # ESP Async WebServer@1.2.0 # use this version of the program exceeds the flash size 
   Time
+  # Time@1.6 # use this version of the program exceeds the flash size 
+  # Note: In Windows IDE there is need to rename "Time.h"  according to https://github.com/esp8266/Arduino/issues/2341
   ArduinoJson
+  # ArduinoJson@6.10.0  # use this version of the program exceeds the flash size 
   Adafruit GFX Library
   Adafruit ILI9341
   U8g2_for_Adafruit_GFX
   ESP32httpUpdate
-
+  # ESP32httpUpdate@2.1.145 # use this version of the program exceeds the flash size 


### PR DESCRIPTION
This branch fixes the following issues in Windows IDE environment:

a) Compile error : 'String' does not name a type via update of AskSinAnalyzerESP32.ino
b) Error: The program size (1398961 bytes) is greater than maximum allowed (1310720 bytes) by adding library versions to platformio.ini
c) Added reference to "Time.h" handling in platformio.ini - It would be useful if this could be updated in the Wiki, also.

Cheers
Juergen

